### PR TITLE
Adding support for sidebar information

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,3 +13,8 @@ ui:
   bundle:
     url: https://github.com/rhpds/showroom_theme_summit/releases/download/v0.0.1/ui-bundle.zip
 ----
+
+== Showing information on the sidebar
+
+The sidebar will show a simple box with the SSH command and the password for the bastion if specific asciidoc attributes
+are set: *page-ssh-command*, *page-ssh-password*

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -275,3 +275,23 @@ html.is-clipped--nav {
   content: " (latest)";
 }
 */
+
+.nav-banner {
+  padding: 10px;
+  border-radius: 10px;
+  border: 2px solid var(--navbar-background);
+}
+
+div.banner-item-title {
+  width: 100%;
+  font-weight: bold;
+}
+
+.nav-banner > div > span {
+  overflow: scroll;
+  white-space: nowrap;
+  scrollbar-width: thin;
+  user-select: all;
+  -moz-user-select: all;
+  -webkit-user-select: all;
+}

--- a/src/partials/nav-banner.hbs
+++ b/src/partials/nav-banner.hbs
@@ -1,0 +1,10 @@
+{{#if page.attributes.ssh-command}}
+<div class="nav-banner">
+{{#with page.attributes.ssh-command}}
+  <div><div class="banner-item-title">Connect:</div> <span class="value">{{this}}</span></div>
+{{/with}}
+{{#with page.attributes.ssh-password}}
+  <div><div class="banner-item-title">Password:</div> <span class="value">{{this}}</span></div>
+{{/with}}
+</div>
+{{/if}}

--- a/src/partials/nav-menu.hbs
+++ b/src/partials/nav-menu.hbs
@@ -1,10 +1,11 @@
-{{#with page.navigation}}
 <div class="nav-panel-menu is-active" data-panel="menu">
   <nav class="nav-menu">
+{{#with page.navigation}}
     {{#with @root.page.componentVersion}}
     <h3 class="title" style="display: none;"><a href="{{{relativize ./url}}}" class=" query-params-link">{{./title}}</a></h3>
     {{/with}}
 {{> nav-tree navigation=this}}
+{{/with}}
+{{> nav-banner}}
   </nav>
 </div>
-{{/with}}


### PR DESCRIPTION
This adds support for showing sidebar information about connecting to the bastion host:

<img width="538" alt="Screenshot 2024-04-23 at 2 54 26 PM" src="https://github.com/rhpds/showroom_theme_summit/assets/376118/cf017821-dd07-4b0e-b9d7-e9e4203191e8">

It requires specific attributes to be set:

```yaml
asciidoc:
  attributes:
    page-ssh-command: ssh lab-user@123.123.123.123
    page-ssh-password: abc123
```